### PR TITLE
T6713 CO2 Sensor Driver

### DIFF
--- a/CISLibrary/drivers/T6713/T6713.cpp
+++ b/CISLibrary/drivers/T6713/T6713.cpp
@@ -1,0 +1,37 @@
+#include "T6713.h"
+
+/**
+ * @brief Construct a new T6713 object
+ * 
+ * @param i2c  The I2C with which the driver works
+ * @param addr The slave address of the sensor on the i2c
+ */
+T6713::T6713(I2C &i2c, uint8_t addr)
+{
+    this->i2c = i2c;
+    this->addr = addr;
+}
+
+/**
+ * @brief Destroy the T6173 object.
+ * As of now, the destructor does not need anything.
+ * 
+ */
+~T6713::T6173()
+{
+
+}
+
+/**
+ * @brief Gets the PPM (CO2 level) reading of the sensor
+ * 
+ * @return int 
+ */
+int T6173::readPPM()
+{
+    char data[4];
+    i2c.write(this->addr, READ_CO2_COMMAND, 5)/;
+    thread_sleep_for(2000);
+    i2c.read(this->addr, data, 4);
+    return (((data[2] & 0x3F ) << 8) | data[3]);
+}

--- a/CISLibrary/drivers/T6713/T6713.cpp
+++ b/CISLibrary/drivers/T6713/T6713.cpp
@@ -2,36 +2,31 @@
 
 /**
  * @brief Construct a new T6713 object
- * 
+ *
  * @param i2c  The I2C with which the driver works
  * @param addr The slave address of the sensor on the i2c
  */
-T6713::T6713(I2C &i2c, uint8_t addr)
-{
-    this->i2c = i2c;
-    this->addr = addr;
+T6713::T6713(I2C & i2c, uint8_t addr) {
+  this->i2c  = i2c;
+  this->addr = addr;
 }
 
 /**
  * @brief Destroy the T6173 object.
  * As of now, the destructor does not need anything.
- * 
+ *
  */
-~T6713::T6173()
-{
-
-}
+~T6713::T6173() {}
 
 /**
  * @brief Gets the PPM (CO2 level) reading of the sensor
- * 
- * @return int 
+ *
+ * @return int
  */
-int T6173::readPPM()
-{
-    char data[4];
-    i2c.write(this->addr, READ_CO2_COMMAND, 5)/;
-    thread_sleep_for(2000);
-    i2c.read(this->addr, data, 4);
-    return (((data[2] & 0x3F ) << 8) | data[3]);
+int T6173::readPPM() {
+  char data[4];
+  i2c.write(this->addr, READ_CO2_COMMAND, 5) / ;
+  thread_sleep_for(2000);
+  i2c.read(this->addr, data, 4);
+  return (((data[2] & 0x3F) << 8) | data[3]);
 }

--- a/CISLibrary/drivers/T6713/T6713.cpp
+++ b/CISLibrary/drivers/T6713/T6713.cpp
@@ -1,6 +1,13 @@
 #include "T6713.h"
 
 /**
+ * @brief Construct a new T6713 object
+ *
+ * @param i2c  The I2C with which the driver works
+ */
+T6713::T6713(I2C & i2c) : i2c(i2c) {}
+
+/**
  * @brief Destroy the T6713 object.
  * As of now, the destructor does not need anything.
  *
@@ -10,21 +17,23 @@ T6713::~T6713() {}
 /**
  * @brief Gets the PPM (CO2 level) reading of the sensor
  *
- * @param outValue Reference to the int variable to be changed to the PPM value
+ * @param outValue Reference to the 16-bit int variable to be changed to the
+ * CO2 concentration in PPM. This 16-bit int datatype is explicity specified
+ * in the sensor's documentation.
  * @return mbed_error_status_t MBED_SUCCESS if the reading was successful,
  * otherwise the error status of the reading
  */
-mbed_error_status_t T6713::readPPM(int & ppmOut) {
+mbed_error_status_t T6713::readPPM(uint16_t & ppmOut) {
   char data[4];
 
-  if (this->i2c.write(this->addr, READ_CO2_COMMAND, 5)) {
+  if (this->i2c.write(T6713::T6713_SLAVE_ADDRESS, T6713::READ_CO2_COMMAND, 5)) {
     return MBED_ERROR_WRITE_FAILED;
   }
 
-  if (this->i2c.read(this->addr, data, 4)) {
+  if (this->i2c.read(T6713::T6713_SLAVE_ADDRESS, data, 4)) {
     return MBED_ERROR_READ_FAILED;
   }
 
-  ppmOut = (((data[2] & 0x3F) << 8) | data[3]);
+  ppmOut = (uint16_t)(((data[2] & 0x3F) << 8) | data[3]);
   return MBED_SUCCESS;
 }

--- a/CISLibrary/drivers/T6713/T6713.cpp
+++ b/CISLibrary/drivers/T6713/T6713.cpp
@@ -1,32 +1,30 @@
 #include "T6713.h"
 
 /**
- * @brief Construct a new T6713 object
- *
- * @param i2c  The I2C with which the driver works
- * @param addr The slave address of the sensor on the i2c
- */
-T6713::T6713(I2C & i2c, uint8_t addr) {
-  this->i2c  = i2c;
-  this->addr = addr;
-}
-
-/**
- * @brief Destroy the T6173 object.
+ * @brief Destroy the T6713 object.
  * As of now, the destructor does not need anything.
  *
  */
-~T6713::T6173() {}
+T6713::~T6713() {}
 
 /**
  * @brief Gets the PPM (CO2 level) reading of the sensor
  *
- * @return int
+ * @param outValue Reference to the int variable to be changed to the PPM value
+ * @return mbed_error_status_t MBED_SUCCESS if the reading was successful,
+ * otherwise the error status of the reading
  */
-int T6173::readPPM() {
+mbed_error_status_t T6713::readPPM(int & ppmOut) {
   char data[4];
-  i2c.write(this->addr, READ_CO2_COMMAND, 5) / ;
-  thread_sleep_for(2000);
-  i2c.read(this->addr, data, 4);
-  return (((data[2] & 0x3F) << 8) | data[3]);
+
+  if (this->i2c.write(this->addr, READ_CO2_COMMAND, 5)) {
+    return MBED_ERROR_WRITE_FAILED;
+  }
+
+  if (this->i2c.read(this->addr, data, 4)) {
+    return MBED_ERROR_READ_FAILED;
+  }
+
+  ppmOut = (((data[2] & 0x3F) << 8) | data[3]);
+  return MBED_SUCCESS;
 }

--- a/CISLibrary/drivers/T6713/T6713.h
+++ b/CISLibrary/drivers/T6713/T6713.h
@@ -1,17 +1,28 @@
 #ifndef _LIBRARY_DRIVER_T6713_H_
 #define _LIBRARY_DRIVER_T6713_H_
 
-// See
-// http://www.co2meters.com/Documentation/Manuals/Manual-AMP-0002-T6713-Sensor.pdf
-// for more detailed documentation of the sensor itself
-
 #include <mbed.h>
 
-// T6713 CO2 Sensor I2C default slave address
-const uint8_t DEFAULT_T6713_SLAVE_ADDRESS = 0x15 << 1;
-// Same command found in the T67XX CO2 Sensor Module documentation, see pg. 29
-static const char READ_CO2_COMMAND[5] = {0x04, 0x13, 0x8B, 0x00, 0x01};
-
+/**
+ * @brief The driver class for working with the T6713 sensor. It is specifically
+ * responsible for reading the CO2 concentration (measured in PPM) from the
+ * sensor.
+ * See
+ * http://www.co2meters.com/Documentation/Manuals/Manual-AMP-0002-T6713-Sensor.pdf
+ * for more detailed documentation of the sensor itself
+ *
+ * Example:
+ * @code
+ *   I2C i2c(I2C_SDA, I2C_SCL);
+ *   T6713 t6713(i2c);
+ *
+ *   uint16_t ppmValue = 0;
+ *   if (t6713.readPPM(ppmValue) == MBED_SUCCESS) {
+ *     printf("PPM value: %d", ppmValue);
+ *   }
+ * @encode
+ *
+ */
 class T6713 {
 public:
   T6713(const T6713 &) = delete;
@@ -21,35 +32,45 @@ public:
    * @brief Construct a new T6713 object
    *
    * @param i2c  The I2C with which the driver works
-   * @param addr The slave address of the sensor on the i2c, defaults to
-   * DEFAULT_T6713_SLAVE_ADDRESS
    */
-  T6713(I2C & i2c, uint8_t addr = DEFAULT_T6713_SLAVE_ADDRESS) :
-    i2c(i2c), addr(addr) {};
+  T6713(I2C & i2c);
 
+  /**
+   * @brief Destroy the T6713 object.
+   * As of now, the destructor does not need anything.
+   *
+   */
   ~T6713();
 
   /**
    * @brief Gets the PPM (CO2 level) reading of the sensor
    *
-   * @param outValue Reference to the int variable to be changed to the PPM
-   * value
+   * @param outValue Reference to the 16-bit int variable to be changed to the
+   * CO2 concentration in PPM. This 16-bit int datatype is explicity specified
+   * in the sensor's documentation.
    * @return mbed_error_status_t MBED_SUCCESS if the reading was successful,
    * otherwise the error status of the reading
    */
-  mbed_error_status_t readPPM(int & outValue);
+  mbed_error_status_t readPPM(uint16_t & outValue);
 
 private:
   /**
-   * @brief The I2C with which the driver works to read the sensor values
+   * @brief The sensor's default I2C slave address
+   *
+   */
+  static const uint8_t T6713_SLAVE_ADDRESS = 0x15 << 1;
+
+  /**
+   * @brief Same command found in the sensor's documentation, see pg. 29
+   *
+   */
+  static constexpr char READ_CO2_COMMAND[5] = {0x04, 0x13, 0x8B, 0x00, 0x01};
+
+  /**
+   * @brief The I2C with which the driver works to read the CO2 concentration
    *
    */
   I2C & i2c;
-  /**
-   * @brief The slave address of the sensor to which the I2C should read/write
-   *
-   */
-  uint8_t addr;
 };
 
 #endif /* _LIBRARY_DRIVER_T6713_H_ */

--- a/CISLibrary/drivers/T6713/T6713.h
+++ b/CISLibrary/drivers/T6713/T6713.h
@@ -6,48 +6,41 @@
 // T6173 CO2 Sensor i2C Address
 const uint8_t DEFAULT_T6713_SLAVE_ADDRESS 0x15 << 1;
 // Same command found in the T67XX CO2 Sensor Module documentation, see pg. 29
-static const uint8_t READ_CO2_COMMAND = {
-    0x04,
-    0x13,
-    0x8B,
-    0x00,
-    0x01
-};
+static const uint8_t READ_CO2_COMMAND = {0x04, 0x13, 0x8B, 0x00, 0x01};
 
-class T6713
-{
+class T6713 {
 public:
-    T6713(const T6173 &) = delete;
-    T6173 & operator=(const T6173 &) = delete;
-    
-    /**
-     * @brief Construct a new T6713 object
-     * 
-     * @param i2c  The I2C with which the driver works
-     * @param addr The slave address of the sensor on the i2c
-     */
-    T6713(I2C &i2c, uint8_t addr = DEFAULT_T6713_SLAVE_ADDRESS);
+  T6713(const T6173 &) = delete;
+  T6173 & operator=(const T6173 &) = delete;
 
-    ~T6173();
+  /**
+   * @brief Construct a new T6713 object
+   *
+   * @param i2c  The I2C with which the driver works
+   * @param addr The slave address of the sensor on the i2c
+   */
+  T6713(I2C & i2c, uint8_t addr = DEFAULT_T6713_SLAVE_ADDRESS);
 
-    /**
-     * @brief Reads the current PPM (CO2 level) that the sensor reads
-     * 
-     * @return int The PPM reading of the sensor
-     */
-    int readPPM();
+  ~T6173();
+
+  /**
+   * @brief Reads the current PPM (CO2 level) that the sensor reads
+   *
+   * @return int The PPM reading of the sensor
+   */
+  int readPPM();
 
 private:
-    /**
-     * @brief The I2C with which the driver works to read the sensor values
-     * 
-     */
-    I2C i2c;
-    /**
-     * @brief The slave address of the sensor on which the I2C should read/write
-     * 
-     */
-    uint8_t addr;
+  /**
+   * @brief The I2C with which the driver works to read the sensor values
+   *
+   */
+  I2C i2c;
+  /**
+   * @brief The slave address of the sensor on which the I2C should read/write
+   *
+   */
+  uint8_t addr;
 };
 
 #endif /* _LIBRARY_DRIVER_T6713_H_ */

--- a/CISLibrary/drivers/T6713/T6713.h
+++ b/CISLibrary/drivers/T6713/T6713.h
@@ -1,0 +1,53 @@
+#ifndef _LIBRARY_DRIVER_T6713_H_
+#define _LIBRARY_DRIVER_T6713_H_
+
+#include <mbed.h>
+
+// T6173 CO2 Sensor i2C Address
+const uint8_t DEFAULT_T6713_SLAVE_ADDRESS 0x15 << 1;
+// Same command found in the T67XX CO2 Sensor Module documentation, see pg. 29
+static const uint8_t READ_CO2_COMMAND = {
+    0x04,
+    0x13,
+    0x8B,
+    0x00,
+    0x01
+};
+
+class T6713
+{
+public:
+    T6713(const T6173 &) = delete;
+    T6173 & operator=(const T6173 &) = delete;
+    
+    /**
+     * @brief Construct a new T6713 object
+     * 
+     * @param i2c  The I2C with which the driver works
+     * @param addr The slave address of the sensor on the i2c
+     */
+    T6713(I2C &i2c, uint8_t addr = DEFAULT_T6713_SLAVE_ADDRESS);
+
+    ~T6173();
+
+    /**
+     * @brief Reads the current PPM (CO2 level) that the sensor reads
+     * 
+     * @return int The PPM reading of the sensor
+     */
+    int readPPM();
+
+private:
+    /**
+     * @brief The I2C with which the driver works to read the sensor values
+     * 
+     */
+    I2C i2c;
+    /**
+     * @brief The slave address of the sensor on which the I2C should read/write
+     * 
+     */
+    uint8_t addr;
+};
+
+#endif /* _LIBRARY_DRIVER_T6713_H_ */

--- a/CISLibrary/drivers/T6713/T6713.h
+++ b/CISLibrary/drivers/T6713/T6713.h
@@ -1,43 +1,52 @@
 #ifndef _LIBRARY_DRIVER_T6713_H_
 #define _LIBRARY_DRIVER_T6713_H_
 
+// See
+// http://www.co2meters.com/Documentation/Manuals/Manual-AMP-0002-T6713-Sensor.pdf
+// for more detailed documentation of the sensor itself
+
 #include <mbed.h>
 
-// T6173 CO2 Sensor i2C Address
-const uint8_t DEFAULT_T6713_SLAVE_ADDRESS 0x15 << 1;
+// T6713 CO2 Sensor I2C default slave address
+const uint8_t DEFAULT_T6713_SLAVE_ADDRESS = 0x15 << 1;
 // Same command found in the T67XX CO2 Sensor Module documentation, see pg. 29
-static const uint8_t READ_CO2_COMMAND = {0x04, 0x13, 0x8B, 0x00, 0x01};
+static const char READ_CO2_COMMAND[5] = {0x04, 0x13, 0x8B, 0x00, 0x01};
 
 class T6713 {
 public:
-  T6713(const T6173 &) = delete;
-  T6173 & operator=(const T6173 &) = delete;
+  T6713(const T6713 &) = delete;
+  T6713 & operator=(const T6713 &) = delete;
 
   /**
    * @brief Construct a new T6713 object
    *
    * @param i2c  The I2C with which the driver works
-   * @param addr The slave address of the sensor on the i2c
+   * @param addr The slave address of the sensor on the i2c, defaults to
+   * DEFAULT_T6713_SLAVE_ADDRESS
    */
-  T6713(I2C & i2c, uint8_t addr = DEFAULT_T6713_SLAVE_ADDRESS);
+  T6713(I2C & i2c, uint8_t addr = DEFAULT_T6713_SLAVE_ADDRESS) :
+    i2c(i2c), addr(addr) {};
 
-  ~T6173();
+  ~T6713();
 
   /**
-   * @brief Reads the current PPM (CO2 level) that the sensor reads
+   * @brief Gets the PPM (CO2 level) reading of the sensor
    *
-   * @return int The PPM reading of the sensor
+   * @param outValue Reference to the int variable to be changed to the PPM
+   * value
+   * @return mbed_error_status_t MBED_SUCCESS if the reading was successful,
+   * otherwise the error status of the reading
    */
-  int readPPM();
+  mbed_error_status_t readPPM(int & outValue);
 
 private:
   /**
    * @brief The I2C with which the driver works to read the sensor values
    *
    */
-  I2C i2c;
+  I2C & i2c;
   /**
-   * @brief The slave address of the sensor on which the I2C should read/write
+   * @brief The slave address of the sensor to which the I2C should read/write
    *
    */
   uint8_t addr;

--- a/CISLibrary/drivers/T6713/T6713.h
+++ b/CISLibrary/drivers/T6713/T6713.h
@@ -54,22 +54,9 @@ public:
   mbed_error_status_t readPPM(uint16_t & outValue);
 
 private:
-  /**
-   * @brief The sensor's default I2C slave address
-   *
-   */
-  static const uint8_t T6713_SLAVE_ADDRESS = 0x15 << 1;
-
-  /**
-   * @brief Same command found in the sensor's documentation, see pg. 29
-   *
-   */
+  static const uint8_t  T6713_SLAVE_ADDRESS = 0x15 << 1;
   static constexpr char READ_CO2_COMMAND[5] = {0x04, 0x13, 0x8B, 0x00, 0x01};
 
-  /**
-   * @brief The I2C with which the driver works to read the CO2 concentration
-   *
-   */
   I2C & i2c;
 };
 


### PR DESCRIPTION
This branch contains just the files for the T6713 class, which acts as a driver for reading PPM values from the T6713 CO2 sensor.

Everything that needs to be documented in the code should have already been documented using the Doxygen format, which means documentation may be automatically generated using the Doxygen software.

I have also tested to make sure the class works properly with the sensor using Bradley's setup as seen in Payload's channel on Slack.